### PR TITLE
image_classification cleanup

### DIFF
--- a/image_classification/drop_pipeline.sh
+++ b/image_classification/drop_pipeline.sh
@@ -1,6 +1,6 @@
 oc delete pipeline/image-classification
-oc delete pipelinerun/tf-build-pipeline-run
-oc delete pipelineresource/build-image
-oc delete pipelineresource/repo
-oc delete task/buildah
-oc delete task/run-benchmark
+oc delete pipelinerun/image-classification-pipeline-run
+oc delete pipelineresource/ic-build-image
+oc delete pipelineresource/ic-repo
+oc delete task/ic-buildah
+oc delete task/ic-run

--- a/image_classification/pipeline/pipeline.yml
+++ b/image_classification/pipeline/pipeline.yml
@@ -12,7 +12,7 @@ spec:
   tasks:
     - name: build
       taskRef:
-        name: buildah
+        name: ic-buildah
         kind: Task
       resources:
         inputs:
@@ -23,7 +23,7 @@ spec:
             resource: build-image
     - name: run
       taskRef:
-        name: run-benchmark
+        name: ic-run
         kind: Task
       resources:
         inputs:

--- a/image_classification/pipeline/pipelinerun.yml
+++ b/image_classification/pipeline/pipelinerun.yml
@@ -1,15 +1,15 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineRun
 metadata:
-  name: tf-build-pipeline-run
+  generateName: image-classification-pipeline-run-
 spec:
-  serviceAccount: image-classification
+  serviceAccount: mlperf
   pipelineRef:
     name: image-classification
   resources:
   - name: repo
     resourceRef:
-      name: repo
+      name: ic-repo
   - name: build-image
     resourceRef:
-      name: build-image
+      name: ic-build-image

--- a/image_classification/pipeline/resources.yml
+++ b/image_classification/pipeline/resources.yml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: repo
+  name: ic-repo
 spec:
   type: git
   params:
@@ -12,10 +12,10 @@ spec:
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: build-image
+  name: ic-build-image
 spec:
   type: image
   params:
     - name: url
-      value: image-registry.openshift-image-registry.svc:5000/mlperf/image-classification:latest
+      value: docker-registry.default.svc:5000/mlperf/image-classification:latest
 ---

--- a/image_classification/pipeline/serviceaccount.yml
+++ b/image_classification/pipeline/serviceaccount.yml
@@ -1,5 +1,0 @@
- 
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: image-classification

--- a/image_classification/task/buildah.yaml
+++ b/image_classification/task/buildah.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
-  name: buildah
+  name: ic-buildah
 spec:
   inputs:
     params:
@@ -26,15 +26,6 @@ spec:
       type: image
 
   steps:
-  - name: ls
-    image: $(inputs.params.BUILDER_IMAGE)
-    workingDir: /workspace/source
-    command: ["ls"]
-    volumeMounts:
-    - name: varlibcontainers
-      mountPath: /var/lib/containers
-    securityContext:
-      privileged: true
   - name: build
     image: $(inputs.params.BUILDER_IMAGE)
     workingDir: /workspace/source

--- a/image_classification/task/buildahrun.yml
+++ b/image_classification/task/buildahrun.yml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun
 metadata:
-  name: buildah-run
+  name: ic-buildah-run
   namespace: mlperf
 spec:
   taskRef:
@@ -11,9 +11,9 @@ spec:
     resources:
       - name: repo
         resourceRef:
-          name: repo
+          name: ic-repo
   outputs:
     resources:
       - name: build-image
         resourceRef:
-          name: build-image
+          name: ic-build-image

--- a/image_classification/task/run-benchmark-taskrun.yml
+++ b/image_classification/task/run-benchmark-taskrun.yml
@@ -1,14 +1,14 @@
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun
 metadata:
-  name: run-run
+  name: ic-taskrun
   namespace: mlperf
 spec:
   taskRef:
-    name: run-benchmark
-  serviceAccount: image-classification
+    name: ic-run
+  serviceAccount: mlperf
   inputs:
     resources:
       - name: build-image
         resourceRef:
-          name: build-image
+          name: ic-build-image

--- a/image_classification/task/run-benchmark.yml
+++ b/image_classification/task/run-benchmark.yml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
-  name: run-benchmark
+  name: ic-run
 spec:
   inputs:
     resources:
@@ -13,10 +13,4 @@ spec:
       workingDir: /mlperf/image_classification/tensorflow
       securityContext:
         privileged: true
-      command: ["/bin/sh", "./run_and_time_result.sh"]
-    - name: ls
-      image: $(inputs.resources.image.url)
-      workingDir: /mlperf
-      securityContext:
-        privileged: true
-      command: ["ls"]
+      command: ["/bin/sh", "./run_and_time.sh"]


### PR DESCRIPTION
After the initial merge for image_classification, I have adopted a naming pattern for the pipeline parts for each benchmark, with -. This way, multiple pipeline parts from different benchmarks can co-exist on the same project, because they do not share the same name.